### PR TITLE
- Update example

### DIFF
--- a/pkg/info-service/images.go
+++ b/pkg/info-service/images.go
@@ -14,14 +14,14 @@ import (
 	https://susepubliccloudinfo.suse.com/VERSION/FRAMEWORK/REGION/images.json
 
   {
-    "name": "suse-sles-11-sp4-sapcal-v20180816-hvm-ssd-x86_64",
+    "name": "suse-sles-15-sp1-v20190624-hvm-ssd-x86_64",
     "state": "active",
     "replacementname": "",
     "replacementid": "",
-    "publishedon": "20180816",
+    "publishedon": "20190624",
     "deprecatedon": "",
     "region": "eu-central-1",
-    "id": "ami-082bfb28e7de47e17",
+    "id": "ami-0352b14942c00b04b",
     "deletedon": ""
   },
 */
@@ -63,7 +63,6 @@ var VALID_IMAGE_STATES = []string{
 	"active",
 	"inactive",
 	"deprecated",
-	"deleted",
 }
 
 // Returns a list of images that match the search criteria provided by


### PR DESCRIPTION
  + Update the example for an image description from the SUSE image info
    service to a more recent image
- Do not consider deleted images
  + In the context of terraform we do not want to consider deleted images.
    These images have been deleted and therefor can no longer be launched in
    a terraform template. To find the complete list of images, including
    deleted images we already have a tool, pint
    https://github.com/SUSE-Enceladus/public-cloud-info-client